### PR TITLE
Fix highlighting for atlas gateways

### DIFF
--- a/models/SkillNode.ts
+++ b/models/SkillNode.ts
@@ -113,7 +113,7 @@ export class SkillNode implements ISkillNode {
         this.arc = this.getArc(this.orbitIndex);
         this.x = this.getX(this.arc);
         this.y = this.getY(this.arc);
-        this.isRegular2 = !this.isKeystone && !this.isNotable && !this.isJewelSocket && !this.isMastery;
+        this.isRegular2 = !this.isKeystone && !this.isNotable && !this.isJewelSocket && !this.isMastery && !this.isWormhole;
         this.isRegular1 = this.isRegular2 && (this.grantedStrength > 0 || this.grantedDexterity > 0 || this.grantedIntelligence > 0) && this.stats.filter(utils.NotNullOrWhiteSpace).length === 1;
         this.patch = patch;
 
@@ -256,8 +256,8 @@ export class SkillNode implements ISkillNode {
         if (this.isNotable || this.isJewelSocket || this.isMastery) {
             return { width: Math.floor(100 * this.scale), height: Math.floor(100 * this.scale) };
         }
-
-        if (this.isKeystone) {
+        
+        if (this.isKeystone || this.isWormhole) {
             return { width: Math.floor(138 * this.scale), height: Math.floor(140 * this.scale) };
         }
 


### PR DESCRIPTION
The atlas gateways were being highlighted as if they were regular2 nodes, causing the highlight circle to appear inside of the gateway icon.