### PR TITLE
Fix for class changing on open URL

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -123,6 +123,9 @@ export class App {
     private SetupEventsAndControls = () => {
         SkillTreeEvents.on("skilltree", "highlighted-nodes-update", this.renderer.RenderHighlight);
         SkillTreeEvents.on("skilltree", "class-change", this.renderer.RenderCharacterStartsActive);
+        SkillTreeEvents.on("skilltree", "class-change", this.updateClassControl);
+        SkillTreeEvents.on("skilltree", "ascendancy-class-change", this.updateAscClassControl);
+
 
         SkillTreeEvents.on("skilltree", "hovered-nodes-start", this.renderer.StartRenderHover);
         SkillTreeEvents.on("skilltree", "hovered-nodes-end", this.renderer.StopRenderHover);
@@ -347,6 +350,49 @@ export class App {
 
         if (ascControl !== null) {
             this.populateAscendancyClasses(ascControl);
+        }
+    }
+
+    private updateClassControl = () => {
+        const start = this.skillTreeData.getStartClass();
+        (document.getElementById("skillTreeControl_Class") as HTMLSelectElement).value = String(start);
+    }
+
+    private updateAscClassControl = () => {
+        if (this.skillTreeData.classes.length === 0) {
+            return;
+        }
+        
+        const start = this.skillTreeData.getAscendancyClass();
+
+        const ascClasses = this.skillTreeData.classes[this.skillTreeData.getStartClass()].ascendancies;
+
+        if (ascClasses === undefined) {
+            return;
+        }
+        const ascControl = (document.getElementById("skillTreeControl_Ascendancy") as HTMLSelectElement);
+
+        while (ascControl.firstChild) {
+            ascControl.removeChild(ascControl.firstChild);
+        }
+        const none = document.createElement("option");
+        none.text = "None";
+        none.value = "0";
+        ascControl.append(none);
+
+        if (this.skillTreeData.classes.length > 0) {
+            for (const ascid in ascClasses) {
+                const asc = ascClasses[ascid];
+
+                const e = document.createElement("option");
+                e.text = asc.name;
+                e.value = ascid;
+
+                if (+ascid === start) {
+                    e.setAttribute("selected", "selected");
+                }
+                ascControl.append(e);
+            }
         }
     }
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -337,7 +337,6 @@ export class App {
         }
 
         const ascControl = document.getElementById("skillTreeControl_Ascendancy") as HTMLSelectElement;
-        SkillTreeEvents.fire("controls", "class-change", +classControl.value);
         classControl.onchange = () => {
             const val = classControl.value;
             SkillTreeEvents.fire("controls", "class-change", +val);

--- a/models/SkillTreeUtilities.ts
+++ b/models/SkillTreeUtilities.ts
@@ -43,6 +43,9 @@ export class SkillTreeUtilities {
 
     private lastHash = "";
     public decodeURL = () => {
+        if(window.location.hash === ""){
+            this.changeStartClass(3, false);
+        }
         if (this.lastHash === window.location.hash) {
             return;
         }
@@ -139,7 +142,7 @@ export class SkillTreeUtilities {
                 this.skillTreeData.removeState(i, SkillNodeStates.Active);
             }
         }
-
+        (document.getElementById("skillTreeControl_Class") as HTMLSelectElement).value = String(start);
         this.changeAscendancyClass(0, false);
 
         if (encode) {
@@ -159,6 +162,31 @@ export class SkillTreeUtilities {
 
         const ascClass = ascClasses[start];
         const name = ascClass !== undefined ? ascClass.name : undefined;
+
+        const ascControl = (document.getElementById("skillTreeControl_Ascendancy") as HTMLSelectElement);
+
+        while (ascControl.firstChild) {
+            ascControl.removeChild(ascControl.firstChild);
+        }
+        const none = document.createElement("option");
+        none.text = "None";
+        none.value = "0";
+        ascControl.append(none);
+
+        if (this.skillTreeData.classes.length > 0) {
+            for (const ascid in ascClasses) {
+                const asc = ascClasses[ascid];
+
+                const e = document.createElement("option");
+                e.text = asc.name;
+                e.value = ascid;
+
+                if (+ascid === start) {
+                    e.setAttribute("selected", "selected");
+                }
+                ascControl.append(e);
+            }
+        }
 
         for (const id in this.skillTreeData.ascedancyNodes) {
             const node = this.skillTreeData.nodes[id];

--- a/models/SkillTreeUtilities.ts
+++ b/models/SkillTreeUtilities.ts
@@ -1,4 +1,4 @@
-﻿import { SkillTreeData } from "./SkillTreeData";
+import { SkillTreeData } from "./SkillTreeData";
 import { SkillNode, SkillNodeStates } from "./SkillNode";
 import { SkillTreeEvents } from "./SkillTreeEvents";
 import * as PIXI from "pixi.js";
@@ -142,7 +142,6 @@ export class SkillTreeUtilities {
                 this.skillTreeData.removeState(i, SkillNodeStates.Active);
             }
         }
-        (document.getElementById("skillTreeControl_Class") as HTMLSelectElement).value = String(start);
         this.changeAscendancyClass(0, false);
 
         if (encode) {
@@ -151,6 +150,7 @@ export class SkillTreeUtilities {
     }
 
     public changeAscendancyClass = (start: number, encode = true) => {
+        SkillTreeEvents.fire("skilltree", "ascendancy-class-change");
         if (this.skillTreeData.classes.length === 0) {
             return;
         }
@@ -163,31 +163,6 @@ export class SkillTreeUtilities {
         const ascClass = ascClasses[start];
         const name = ascClass !== undefined ? ascClass.name : undefined;
 
-        const ascControl = (document.getElementById("skillTreeControl_Ascendancy") as HTMLSelectElement);
-
-        while (ascControl.firstChild) {
-            ascControl.removeChild(ascControl.firstChild);
-        }
-        const none = document.createElement("option");
-        none.text = "None";
-        none.value = "0";
-        ascControl.append(none);
-
-        if (this.skillTreeData.classes.length > 0) {
-            for (const ascid in ascClasses) {
-                const asc = ascClasses[ascid];
-
-                const e = document.createElement("option");
-                e.text = asc.name;
-                e.value = ascid;
-
-                if (+ascid === start) {
-                    e.setAttribute("selected", "selected");
-                }
-                ascControl.append(e);
-            }
-        }
-
         for (const id in this.skillTreeData.ascedancyNodes) {
             const node = this.skillTreeData.nodes[id];
             if (node.ascendancyName !== name) {
@@ -196,7 +171,6 @@ export class SkillTreeUtilities {
             }
             if (node.isAscendancyStart) {
                 this.skillTreeData.addState(node, SkillNodeStates.Active);
-                SkillTreeEvents.fire("skilltree", "ascendancy-class-change", node);
             }
         }
 

--- a/models/SkillTreeUtilities.ts
+++ b/models/SkillTreeUtilities.ts
@@ -142,15 +142,15 @@ export class SkillTreeUtilities {
                 this.skillTreeData.removeState(i, SkillNodeStates.Active);
             }
         }
-        this.changeAscendancyClass(0, false);
+        this.changeAscendancyClass(0, false, true);
 
         if (encode) {
             this.encodeURL();
         }
     }
 
-    public changeAscendancyClass = (start: number, encode = true) => {
-        SkillTreeEvents.fire("skilltree", "ascendancy-class-change");
+    public changeAscendancyClass = (start: number, encode = true, newStart = false) => {
+        if(newStart) SkillTreeEvents.fire("skilltree", "ascendancy-class-change");
         if (this.skillTreeData.classes.length === 0) {
             return;
         }


### PR DESCRIPTION
When opening a poeskilltree.com URL, the class always resets to witch. This currently removes all nodes, meaning you cannot share poeskilltree URLs at the moment. This fixes it so that the class import from the URL is not overridden by the class change event fired by the populateStartClasses function. I'm assuming there's some delay from a fired event being processed, and that delay may depend on a user's device. At least in my case, the fired event in populateStartClasses is always processed after decodeURL has already finished.

I'm not a huge fan of how I'm essentially duplicating code from the initial populating of ascendancies in the change ascendancies bit, but it functions at least. Up to you whether it's too hacky to be merged or not.