### PR TITLE
Fix Maven stat group

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -162,7 +162,7 @@ export class App {
     private buildStatLookups = (defaultGroup: string): [masteries: string[], masteryTest: { [name: string]: string }, defaultStats: { [stat: string]: boolean }] => {
         if (this.masteries === undefined || this.masteryTest === undefined) {
             const masteries: string[] = ["The Maven"];
-            const masteryTest: { [name: string]: string } = {}
+            const masteryTest: { [name: string]: string } = {"The Maven": " Maven"}
             for (const id in this.skillTreeData.nodes) {
                 const node = this.skillTreeData.nodes[id];
                 const mastery = this.skillTreeData.getMasteryForGroup(node.nodeGroup);


### PR DESCRIPTION
Since the maven passives don't have a mastery, they weren't being picked up as Maven passives and instead went into the default category. This adds it to the masteryTest variable and allows it to be a stat group.