### PR TITLE
Don't count multiple choice roots as a node for node counts

### DIFF
--- a/models/SkillTreeUtilities.ts
+++ b/models/SkillTreeUtilities.ts
@@ -95,7 +95,7 @@ export class SkillTreeUtilities {
         const nodes = this.skillTreeData.getNodes(SkillNodeStates.Active);
         for (const id in nodes) {
             const node = nodes[id];
-            if (node.classStartIndex === undefined && !node.isAscendancyStart) {
+            if (node.classStartIndex === undefined && !node.isAscendancyStart && !node.isMultipleChoice) {
                 if (node.ascendancyName === "") {
                     normalNodes++;
                 } else {


### PR DESCRIPTION
This affects the warlock alt ascendancy, but also ascendant. The below image should count as 8 nodes, not 10.
![image](https://github.com/EmmittJ/SkillTree_TypeScript/assets/5985728/0bb0b212-1dfc-4c57-8181-ef6ad3502789)
