### PR TITLE
Fix tooltip reminder text

### DIFF
--- a/models/PIXISkillTreeRenderer.ts
+++ b/models/PIXISkillTreeRenderer.ts
@@ -748,6 +748,8 @@ export class PIXISkillTreeRenderer extends BaseSkillTreeRenderer {
             }
 
             if (reminder !== null) {
+                reminder.style.wordWrap = true;
+                reminder.style.wordWrapWidth = tooltip.width;
                 tooltip.addChild(reminder);
                 reminder.position.set(0, height);
                 height += reminder.height;

--- a/models/SkillNode.ts
+++ b/models/SkillNode.ts
@@ -101,7 +101,7 @@ export class SkillNode implements ISkillNode {
         this.orbitIndex = node.orbitIndex;
         this.out = node.out;
         this.recipe = node.recipe || [];
-        this.reminderText = node.recipe || [];
+        this.reminderText = node.reminderText || [];
         this.skill = node.skill;
         this.stats = node.stats;
 


### PR DESCRIPTION
Fixes tooltip reminder text. Deadly Prey is an example of a node that has reminder text.
![image](https://github.com/EmmittJ/SkillTree_TypeScript/assets/5985728/bdc3dc9b-fad8-4011-adff-bde2ae6a2d16)
